### PR TITLE
Add AWS profile variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ module "ecr_docker_build" {
   # The region which we will log into with aws-cli
   aws_region = "eu-west-1"
 
+  # The aws profile used in aws-cli (Defaults to 'default')
+  aws_profile = "default"
+
   # ECR repository where we can push
   ecr_repository_url = "${aws_ecr_repository.test_service.repository_url}"
 }

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -8,9 +8,12 @@ build_folder=$1
 aws_ecr_repository_url_with_tag=$2
 # kept for backwards compatibility
 aws_region=$3
+aws_profile=$4
 
 # Allow overriding the aws region from system
-if [ "$aws_region" != "" ]; then
+if [ "$aws_profile" != "" ]; then
+  aws_extra_flags="--region $aws_region --profile $aws_profile"
+elif [ "$aws_region" != "" ]; then
   aws_extra_flags="--region $aws_region"
 else
   aws_extra_flags=""

--- a/main.tf
+++ b/main.tf
@@ -10,9 +10,8 @@ resource "null_resource" "build_and_push" {
   }
 
   # See build.sh for more details
-  # See build.sh for more details
   provisioner "local-exec" {
-    command = "${path.module}/bin/build.sh ${var.dockerfile_folder} ${var.ecr_repository_url}:${var.docker_image_tag} ${var.aws_region}"
+    command = "${path.module}/bin/build.sh ${var.dockerfile_folder} ${var.ecr_repository_url}:${var.docker_image_tag} ${var.aws_region} ${var.aws_profile}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "aws_region" {
   default     = ""
 }
 
+variable "aws_profile" {
+  type        = string
+  description = "AWS profile used in AWS CLI"
+  default     = "default"
+}
+
 variable "ecr_repository_url" {
   type        = string
   description = "Full url for the ecr repository"


### PR DESCRIPTION
Add the ability to select the profile used by AWS CLI, which is useful when not working with the default profile.