### PR TITLE
adding output id of build_and_push null_resource

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,3 +3,6 @@ output "ecr_image_url" {
   description = "Full URL to image in ecr with tag"
 }
 
+output "build_id" {
+  value = null_resource.build_and_push.id
+}


### PR DESCRIPTION
This allows other resources to depends_on the docker image. Trying to have lambda depend on the uri lead to race conditions.